### PR TITLE
Remove global API_KEY check

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -600,8 +600,15 @@ export async function generateTestPlan(
     module: string,
     onProgress: (message: string) => void
 ): Promise<string> {
-    if (!process.env.API_KEY) {
-        throw new Error("A variável de ambiente API_KEY não está configurada.");
+    const provider = process.env.LLM_PROVIDER?.toLowerCase();
+    if (provider === 'openai' && !process.env.OPENAI_API_KEY) {
+        throw new Error("A variável de ambiente OPENAI_API_KEY não está configurada.");
+    }
+    if (provider === 'groq' && !process.env.GROQ_API_KEY) {
+        throw new Error("A variável de ambiente GROQ_API_KEY não está configurada.");
+    }
+    if (provider === 'gemini' && !process.env.GEMINI_API_KEY && !process.env.API_KEY) {
+        throw new Error("A variável de ambiente GEMINI_API_KEY não está configurada.");
     }
     
     const finalProgramName = programName || "Programa Desconhecido";


### PR DESCRIPTION
## Summary
- validate provider-specific variables from `LLM_PROVIDER`
- remove legacy `API_KEY` guard

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c0e075acc832e8e16459797f4b86e