### PR TITLE
Update Vite define env vars

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,11 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.OPENAI_API_KEY': JSON.stringify(env.OPENAI_API_KEY),
+        'process.env.GROQ_API_KEY': JSON.stringify(env.GROQ_API_KEY),
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.LLM_PROVIDER': JSON.stringify(env.LLM_PROVIDER),
+        'process.env.TOP_MODEL_PWD': JSON.stringify(env.TOP_MODEL_PWD)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- include missing env vars in `vite.config.ts`
- remove obsolete `API_KEY` define entry

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c0e4ba7d0832e94c5197cd842b7cf