### PR TITLE
Add provider selection and dynamic LLM models

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -54,6 +54,7 @@ const App: React.FC = () => {
   const [manufacturingBranch, setManufacturingBranch] = useState<string>('0015');
   const [distributionBranch, setDistributionBranch] = useState<string>('0030');
   const [module, setModule] = useState<string>('Manufatura');
+  const [llmProvider, setLlmProvider] = useState<string>(process.env.LLM_PROVIDER || 'openai');
 
   const isSpecAnalysis = functionalSpecFiles.length > 0;
   const isCodeAnalysis = customFile !== null;
@@ -176,6 +177,7 @@ const App: React.FC = () => {
           manufacturingBranch, 
           distributionBranch,
           module,
+          llmProvider,
           setProgress
       );
       setReport(result);
@@ -245,7 +247,7 @@ const App: React.FC = () => {
             
             <div className="p-4 bg-slate-50 border border-slate-200 rounded-lg space-y-4">
                  <h3 className="font-semibold text-slate-700 -mb-2">Contexto da Empresa (Opcional)</h3>
-                 <div className="space-y-2">
+                <div className="space-y-2">
                     <label htmlFor="module-select" className="font-semibold text-slate-600 text-sm">Módulo Principal</label>
                     <select
                         id="module-select"
@@ -256,6 +258,19 @@ const App: React.FC = () => {
                         <option value="Manufatura">Manufatura</option>
                         <option value="Distribuição">Distribuição</option>
                         <option value="Financeiro">Financeiro</option>
+                    </select>
+                </div>
+                <div className="space-y-2">
+                    <label htmlFor="provider-select" className="font-semibold text-slate-600 text-sm">Modelo de IA</label>
+                    <select
+                        id="provider-select"
+                        value={llmProvider}
+                        onChange={(e) => setLlmProvider(e.target.value)}
+                        className="w-full p-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition bg-white"
+                    >
+                        <option value="openai">OpenAI</option>
+                        <option value="groq">Groq</option>
+                        <option value="gemini">Gemini</option>
                     </select>
                 </div>
                  <div className="space-y-2">

--- a/lib/llmClient.ts
+++ b/lib/llmClient.ts
@@ -8,6 +8,7 @@ export interface ChatArgs {
   systemPrompt?: string;
   temperature?: number;
   responseMimeType?: string;
+  provider?: string;
 }
 
 export interface ChatResponse {
@@ -32,7 +33,7 @@ export function unlockTopModel(pwd: string) {
 }
 
 export async function generateChat(args: ChatArgs): Promise<ChatResponse> {
-  const provider = process.env.LLM_PROVIDER || 'openai';
+  const provider = args.provider || process.env.LLM_PROVIDER || 'openai';
   const model = args.model;
   if (RESTRICTED_MODELS.includes(model) && !unlocked) {
     throw new Error('401');

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -54,7 +54,17 @@ function createFunctionDiff(vanillaCode: string, customCode: string): string {
     }).filter(Boolean).join('\n');
 }
 
-async function parseAndCorrectJson(text: string): Promise<any> {
+const DEFAULT_MODELS: Record<string, string> = {
+    openai: 'gpt-3.5-turbo-0125',
+    groq: 'groq/llama3-8b-8192',
+    gemini: 'gemini-2.5-flash'
+};
+
+function getModel(provider: string): string {
+    return DEFAULT_MODELS[provider] || DEFAULT_MODELS['openai'];
+}
+
+async function parseAndCorrectJson(text: string, provider: string): Promise<any> {
     const fenceRegex = /^`{3}(json)?\s*\n?(.*?)\n?`{3}$/s;
     let jsonText = text.trim();
     const match = jsonText.match(fenceRegex);
@@ -67,7 +77,8 @@ async function parseAndCorrectJson(text: string): Promise<any> {
         console.warn("Análise JSON inicial falhou. Tentando autocorreção...", { error: e, text: jsonText });
         const prompt = `O seguinte texto deveria ser um JSON, mas está malformado. Por favor, corrija-o e retorne apenas o objeto JSON válido.\n\nJSON Inválido:\n${jsonText}`;
         const result = await generateChat({
-            model: 'gemini-2.5-flash',
+            model: getModel(provider),
+            provider,
             prompt,
             systemPrompt: systemInstructionForJsonFix,
             temperature: 0,
@@ -306,6 +317,7 @@ async function runFunctionalSpecAnalysis(
     manufacturingBranch: string,
     distributionBranch: string,
     module: string,
+    provider: string,
     onProgress: (message: string) => void
 ): Promise<string> {
     onProgress('Analisando especificações funcionais...');
@@ -362,7 +374,8 @@ async function runFunctionalSpecAnalysis(
     }
 
     const response = await generateChat({
-         model: 'gemini-2.5-flash',
+         model: getModel(provider),
+         provider,
          prompt: promptText,
          systemPrompt: "Sua resposta deve ser um documento HTML completo e válido, baseado estritamente nas informações e metodologia fornecidas. Foque em uma linguagem de negócios clara, use <strong> para negrito e garanta cobertura total dos requisitos."
     });
@@ -377,11 +390,12 @@ async function runFunctionalSpecAnalysis(
 
 
 async function runMultiStepAnalysis(
-    vanillaCode: string, 
-    customCode: string, 
+    vanillaCode: string,
+    customCode: string,
     programName: string,
-    manufacturingBranch: string, 
-    distributionBranch: string, 
+    manufacturingBranch: string,
+    distributionBranch: string,
+    provider: string,
     onProgress: (message: string) => void
 ): Promise<string> {
     const isFromScratch = !vanillaCode.trim();
@@ -391,7 +405,7 @@ async function runMultiStepAnalysis(
 
     if (customFunctions.size === 0) {
         onProgress('Nenhuma função C-like encontrada. Realizando análise simples...');
-        return runSimpleAnalysis(vanillaCode, customCode, programName, manufacturingBranch, distributionBranch);
+        return runSimpleAnalysis(vanillaCode, customCode, programName, manufacturingBranch, distributionBranch, provider);
     }
     
     const functionsToAnalyze: { name: string, content: string, type: 'diff' | 'full' }[] = [];
@@ -434,7 +448,8 @@ async function runMultiStepAnalysis(
                 : getComprehensionPrompt_FromScratch(func.name, programName, func.content);
 
             const comprehensionResult = await generateChat({
-                model: 'gemini-2.5-flash',
+                model: getModel(provider),
+                provider,
                 prompt: comprehensionPrompt,
                 systemPrompt: systemInstructionAntiHallucination,
                 temperature: 0.1
@@ -445,13 +460,14 @@ async function runMultiStepAnalysis(
             onProgress(`Gerando testes para a função ${i + 1}/${functionsToAnalyze.length}: ${func.name}`);
             const testCasePrompt = getTestCaseGenerationPrompt(func.name, programName, analysisContext, manufacturingBranch, distributionBranch);
             const testCaseResponse = await generateChat({
-                model: 'gemini-2.5-flash',
+                model: getModel(provider),
+                provider,
                 prompt: testCasePrompt,
                 systemPrompt: systemInstructionAntiHallucination,
                 temperature: 0.2,
                 responseMimeType: "application/json"
             });
-            const parsedJson = await parseAndCorrectJson(testCaseResponse.content);
+            const parsedJson = await parseAndCorrectJson(testCaseResponse.content, provider);
             if (parsedJson && parsedJson.test_scenarios && Array.isArray(parsedJson.test_scenarios)) {
                 allTestScenarios = allTestScenarios.concat(parsedJson.test_scenarios);
             }
@@ -476,7 +492,8 @@ async function runMultiStepAnalysis(
         try {
             const transcriptionPrompt = getTranscriptionPrompt(JSON.stringify(batch), i + 1);
             const response = await generateChat({
-                model: 'gemini-2.5-flash',
+                model: getModel(provider),
+                provider,
                 prompt: transcriptionPrompt,
                 systemPrompt: systemInstructionAntiHallucination,
                 temperature: 0
@@ -505,7 +522,7 @@ async function runMultiStepAnalysis(
     return assembleFinalReport(programName, metrics, allTableRows, isFromScratch);
 }
 
-async function runSimpleAnalysis(vanillaCode: string, customCode: string, programName: string, manufacturingBranch: string, distributionBranch: string): Promise<string> {
+async function runSimpleAnalysis(vanillaCode: string, customCode: string, programName: string, manufacturingBranch: string, distributionBranch: string, provider: string): Promise<string> {
     const isFromScratch = !vanillaCode.trim();
 
     let prompt: string;
@@ -562,7 +579,8 @@ async function runSimpleAnalysis(vanillaCode: string, customCode: string, progra
     }
 
     const response = await generateChat({
-         model: 'gemini-2.5-flash',
+         model: getModel(provider),
+         provider,
          prompt,
          systemPrompt: "Sua resposta deve ser um documento HTML completo e válido, baseado estritamente na metodologia fornecida. Garanta cobertura total das mudanças ou funcionalidades do código."
     });
@@ -578,17 +596,18 @@ async function runSimpleAnalysis(vanillaCode: string, customCode: string, progra
 
 
 export async function generateTestPlan(
-    vanillaCode: string, 
+    vanillaCode: string,
     customCode: string,
     functionalSpecs: FunctionalSpec[],
-    programName: string, 
+    programName: string,
     includeEnhancedAnalysis: boolean,
     manufacturingBranch: string,
     distributionBranch: string,
     module: string,
+    provider: string,
     onProgress: (message: string) => void
 ): Promise<string> {
-    const provider = process.env.LLM_PROVIDER?.toLowerCase();
+    provider = (provider || process.env.LLM_PROVIDER || 'openai').toLowerCase();
     if (provider === 'openai' && !process.env.OPENAI_API_KEY) {
         throw new Error("A variável de ambiente OPENAI_API_KEY não está configurada.");
     }
@@ -603,7 +622,7 @@ export async function generateTestPlan(
 
     // Prioritize functional spec analysis
     if (functionalSpecs && functionalSpecs.length > 0) {
-        return runFunctionalSpecAnalysis(functionalSpecs, finalProgramName, manufacturingBranch, distributionBranch, module, onProgress);
+        return runFunctionalSpecAnalysis(functionalSpecs, finalProgramName, manufacturingBranch, distributionBranch, module, provider, onProgress);
     }
 
     if (!customCode.trim()) {
@@ -612,9 +631,9 @@ export async function generateTestPlan(
 
     if (includeEnhancedAnalysis) {
         onProgress('Executando análise detalhada de código...');
-        return runMultiStepAnalysis(vanillaCode, customCode, finalProgramName, manufacturingBranch, distributionBranch, onProgress);
+        return runMultiStepAnalysis(vanillaCode, customCode, finalProgramName, manufacturingBranch, distributionBranch, provider, onProgress);
     } else {
         onProgress('Executando análise simples de código...');
-        return runSimpleAnalysis(vanillaCode, customCode, finalProgramName, manufacturingBranch, distributionBranch);
+        return runSimpleAnalysis(vanillaCode, customCode, finalProgramName, manufacturingBranch, distributionBranch, provider);
     }
 }


### PR DESCRIPTION
## Summary
- let user choose the LLM provider in the UI
- plumb provider through `generateTestPlan`
- select default models per provider
- allow overriding provider in `generateChat`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c17b6c434832e998aa96f3be77546