### PR TITLE
Enable runtime LLM selection

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -54,6 +54,11 @@ const App: React.FC = () => {
   const [manufacturingBranch, setManufacturingBranch] = useState<string>('0015');
   const [distributionBranch, setDistributionBranch] = useState<string>('0030');
   const [module, setModule] = useState<string>('Manufatura');
+  const [llmProvider, setLlmProvider] = useState<string>(process.env.LLM_PROVIDER || 'openai');
+
+  useEffect(() => {
+    (globalThis as any).__llmProvider = llmProvider;
+  }, [llmProvider]);
 
   const isSpecAnalysis = functionalSpecFiles.length > 0;
   const isCodeAnalysis = customFile !== null;
@@ -207,6 +212,20 @@ const App: React.FC = () => {
               <SparklesIcon className="w-6 h-6 text-indigo-500" />
               Configuração da Análise
             </h2>
+
+            <div className="space-y-2">
+              <label htmlFor="llm-provider" className="font-semibold text-slate-600 text-sm">Modelo LLM</label>
+              <select
+                id="llm-provider"
+                value={llmProvider}
+                onChange={(e) => setLlmProvider(e.target.value)}
+                className="w-full p-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition bg-white"
+              >
+                <option value="openai">OpenAI</option>
+                <option value="groq">Groq</option>
+                <option value="gemini">Gemini</option>
+              </select>
+            </div>
             
             <div className="space-y-4 p-4 border border-slate-200 rounded-lg">
                 <h3 className="font-semibold text-slate-700 -mb-2">Análise por Código-Fonte</h3>

--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ This contains everything you need to run your app locally.
    - `LLM_PROVIDER` selects the LLM service (`openai`, `groq`, or `gemini`).
    - Provide only the API key for that provider (`OPENAI_API_KEY`, `GROQ_API_KEY`, or `GEMINI_API_KEY`).
    - Premium model IDs (`o3`, `o4`, `gpt-4.1`, `gpt-4.5`) also require the `TOP_MODEL_PWD` variable.
+   - Você pode trocar o provedor pela combobox **Modelo LLM** na tela principal.
 3. Run the app:
    `npm run dev`

--- a/lib/llmClient.ts
+++ b/lib/llmClient.ts
@@ -32,7 +32,7 @@ export function unlockTopModel(pwd: string) {
 }
 
 export async function generateChat(args: ChatArgs): Promise<ChatResponse> {
-  const provider = process.env.LLM_PROVIDER || 'openai';
+  const provider = (globalThis as any).__llmProvider || process.env.LLM_PROVIDER || 'openai';
   const model = args.model;
   if (RESTRICTED_MODELS.includes(model) && !unlocked) {
     throw new Error('401');

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -588,7 +588,7 @@ export async function generateTestPlan(
     module: string,
     onProgress: (message: string) => void
 ): Promise<string> {
-    const provider = process.env.LLM_PROVIDER?.toLowerCase();
+    const provider = ((globalThis as any).__llmProvider || process.env.LLM_PROVIDER || 'openai').toLowerCase();
     if (provider === 'openai' && !process.env.OPENAI_API_KEY) {
         throw new Error("A variável de ambiente OPENAI_API_KEY não está configurada.");
     }


### PR DESCRIPTION
## Summary
- add dropdown to choose which LLM provider to use
- store selection globally so `generateChat` and `generateTestPlan` respect it
- document provider selection in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c17b6c434832e998aa96f3be77546