### PR TITLE
Add model chooser per provider

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { FileUploader } from './components/FileUploader';
 import { ReportDisplay } from './components/ReportDisplay';
 import { AnalysisInfo } from './components/AnalysisInfo';
 import { generateTestPlan, FunctionalSpec } from './services/geminiService';
+import { MODELS_BY_PROVIDER, getModel } from './lib/models';
 import { GeminiIcon, SparklesIcon } from './components/Icons';
 import { MultiFileUploader } from './components/MultiFileUploader';
 import mammoth from 'mammoth';
@@ -55,10 +56,15 @@ const App: React.FC = () => {
   const [distributionBranch, setDistributionBranch] = useState<string>('0030');
   const [module, setModule] = useState<string>('Manufatura');
   const [llmProvider, setLlmProvider] = useState<string>(process.env.LLM_PROVIDER || 'openai');
+  const [llmModel, setLlmModel] = useState<string>(getModel(llmProvider));
 
   const isSpecAnalysis = functionalSpecFiles.length > 0;
   const isCodeAnalysis = customFile !== null;
   const analysisChosen = isSpecAnalysis || isCodeAnalysis;
+
+  useEffect(() => {
+    setLlmModel(getModel(llmProvider));
+  }, [llmProvider]);
 
   useEffect(() => {
     const fileForName = vanillaFile || customFile;
@@ -178,6 +184,7 @@ const App: React.FC = () => {
           distributionBranch,
           module,
           llmProvider,
+          llmModel,
           setProgress
       );
       setReport(result);
@@ -271,6 +278,19 @@ const App: React.FC = () => {
                         <option value="openai">OpenAI</option>
                         <option value="groq">Groq</option>
                         <option value="gemini">Gemini</option>
+                    </select>
+                </div>
+                <div className="space-y-2">
+                    <label htmlFor="model-select" className="font-semibold text-slate-600 text-sm">Modelo</label>
+                    <select
+                        id="model-select"
+                        value={llmModel}
+                        onChange={(e) => setLlmModel(e.target.value)}
+                        className="w-full p-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition bg-white"
+                    >
+                        {MODELS_BY_PROVIDER[llmProvider].map(m => (
+                            <option key={m} value={m}>{m}</option>
+                        ))}
                     </select>
                 </div>
                  <div className="space-y-2">

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,0 +1,25 @@
+export const MODELS_BY_PROVIDER = {
+  openai: [
+    'gpt-4o-mini',
+    'gpt-4o',
+    'gpt-4.1-mini',
+    'gpt-4.1-nano',
+    'gpt-3.5-turbo-0125',
+    'o3',
+    'o4',
+    'gpt-4.1',
+    'gpt-4.5'
+  ],
+  groq: ['groq/llama3-8b-8192'],
+  gemini: ['gemini-2.5-flash']
+} as const;
+
+export const DEFAULT_MODELS: Record<string, string> = {
+  openai: 'gpt-3.5-turbo-0125',
+  groq: 'groq/llama3-8b-8192',
+  gemini: 'gemini-2.5-flash'
+};
+
+export function getModel(provider: string): string {
+  return DEFAULT_MODELS[provider] || DEFAULT_MODELS['openai'];
+}


### PR DESCRIPTION
## Summary
- let users pick the exact model when generating the test plan
- share model list and defaults in `lib/models.ts`
- update service layer to accept explicit model
- update UI to display model dropdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c1f22f224832eba010190d19e9bcc