### PR TITLE
Add password prompt for premium models

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,7 @@ import { FileUploader } from './components/FileUploader';
 import { ReportDisplay } from './components/ReportDisplay';
 import { AnalysisInfo } from './components/AnalysisInfo';
 import { generateTestPlan, FunctionalSpec } from './services/geminiService';
-import { PROVIDER_MODELS, unlockTopModel } from './lib/llmClient';
+import { PROVIDER_MODELS, unlockTopModel, RESTRICTED_MODELS } from './lib/llmClient';
 import { GeminiIcon, SparklesIcon } from './components/Icons';
 import { MultiFileUploader } from './components/MultiFileUploader';
 import mammoth from 'mammoth';
@@ -138,6 +138,22 @@ const App: React.FC = () => {
       } else {
           setProcessedSpecs([]);
       }
+  };
+
+  const handleModelChange = (model: string) => {
+    if ((RESTRICTED_MODELS as readonly string[]).includes(model)) {
+      const pwd = window.prompt('Senha para modelos avançados (ddmmaa):');
+      if (!pwd) {
+        return;
+      }
+      try {
+        unlockTopModel(pwd);
+      } catch (err) {
+        setError('Senha incorreta.');
+        return;
+      }
+    }
+    setLlmModel(model);
   };
 
   const processSpecFile = (file: File): Promise<FunctionalSpec> => {
@@ -295,7 +311,7 @@ const App: React.FC = () => {
                     <select
                         id="model-select"
                         value={llmModel}
-                        onChange={(e) => setLlmModel(e.target.value)}
+                        onChange={(e) => handleModelChange(e.target.value)}
                         className="w-full p-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition bg-white"
                     >
                         {(PROVIDER_MODELS[llmProvider] || PROVIDER_MODELS.openai).map(m => (

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ This contains everything you need to run your app locally.
 2. Create a `.env.local` file and set your provider credentials:
    - `LLM_PROVIDER` selects the LLM service (`openai`, `groq`, or `gemini`).
    - Provide only the API key for that provider (`OPENAI_API_KEY`, `GROQ_API_KEY`, or `GEMINI_API_KEY`).
-   - Premium model IDs (`o3`, `o4`, `gpt-4.1`, `gpt-4.5`) also require the `TOP_MODEL_PWD` variable.
+   - Premium model IDs (`o3`, `o4`, `gpt-4.1`, `gpt-4.5`) exigem uma senha diária (formato `ddmmaa`) ao serem selecionados.
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- lock premium models behind a daily password
- document the password requirement

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cf26c8d68832e9aa527b6a321cb6e