### PR TITLE
Fix Groq model name to avoid 404 errors

### DIFF
--- a/lib/costEstimator.ts
+++ b/lib/costEstimator.ts
@@ -4,7 +4,7 @@ export const PRICE_TABLE = {
   "gpt-4.1-mini":  {in: 0.0004, out: 0.0016},
   "gpt-4.1-nano":  {in: 0.0002, out: 0.0008},
   "gpt-3.5-turbo-0125": {in: 0.0005, out: 0.0015},
-  "groq/llama3-8b-8192": {in: 0.00005, out: 0.00008}
+  "llama3-8b-8192": {in: 0.00005, out: 0.00008}
 } as const;
 
 export function estimateUSD(modelId: string, inTok: number, outTok: number): number {

--- a/lib/llmClient.ts
+++ b/lib/llmClient.ts
@@ -14,7 +14,7 @@ export const PROVIDER_MODELS: Record<string, string[]> = {
     'gpt-4.1',
     'gpt-4.5'
   ],
-  groq: ['groq/llama3-8b-8192'],
+  groq: ['llama3-8b-8192'],
   gemini: ['gemini-2.5-flash']
 } as const;
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -56,7 +56,7 @@ function createFunctionDiff(vanillaCode: string, customCode: string): string {
 
 const DEFAULT_MODELS: Record<string, string> = {
     openai: 'gpt-3.5-turbo-0125',
-    groq: 'groq/llama3-8b-8192',
+    groq: 'llama3-8b-8192',
     gemini: 'gemini-2.5-flash'
 };
 


### PR DESCRIPTION
## Summary
- update the Groq model id to `llama3-8b-8192`
- use the same id in service defaults and price table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d09950638832eb9b82b929df01e7c