### PR TITLE
feat: add Granado Phebo branding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -258,12 +258,20 @@ const App: React.FC = () => {
     <div className="min-h-screen bg-slate-100 font-sans">
       <main className="container mx-auto px-4 py-8">
         <header className="text-center mb-10">
+          <img
+            src="https://i.postimg.cc/PrF15RsV/Logo-Granado-Verde.png"
+            alt="Logo Granado Phebo"
+            className="mx-auto mb-4 w-40 h-auto"
+          />
           <div className="flex items-center justify-center gap-4">
              <GeminiIcon className="w-12 h-12 text-blue-600" />
             <h1 className="text-4xl font-bold text-slate-800">Gerador de Plano de Testes</h1>
           </div>
           <p className="text-lg text-slate-600 mt-2">
             Acelere a geração de Planos de Testes através das Especificações Funcionais ou do Código-Fonte
+          </p>
+          <p className="text-md text-slate-500 mt-1">
+            Personalizado para <span className="font-semibold">Granado Phebo</span>
           </p>
         </header>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gerador de Plano de Testes</title>
+    <title>Gerador de Plano de Testes - Granado Phebo</title>
     <script src="https://cdn.tailwindcss.com"></script>
   <script type="importmap">
 {


### PR DESCRIPTION
## Summary
- add Granado Phebo logo and brand mention to main header
- update page title with company name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f66883234832e83882d1c96bcaf5e